### PR TITLE
Fix outline painting in Example 19

### DIFF
--- a/examples/code/example19.html
+++ b/examples/code/example19.html
@@ -34,6 +34,7 @@
 		grid-column: 3 / 6;
 		grid-row: 2 / 3;
 		outline: 2px solid red;
+		z-index: 10;
 	}
 
    </style>


### PR DESCRIPTION
As per discussion in https://github.com/FremyCompany/css-grid-polyfill/issues/13 once the background paint order is fixed in Chromium, the outline will be painted overlapped by other items.

Setting the z-index properties ensure that it's always painted on top, highlighting properly the element in this example.
