### PR TITLE
Add shrink-to-fit to viewport meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <!-- Bootstrap -->


### PR DESCRIPTION
Hi Rachel,

After coming across a tweet by Trent Walton linking to this great resource, I noticed that toggling the menu caused the site to rapidly zoom out. I thought this might be my first encounter with the infamous [iOS 9 viewport scaling bug](https://forums.developer.apple.com/thread/13510). According to that thread, and to [Bram.us](https://www.bram.us/2015/10/06/ios9-mobilesafari-viewport-problem/), adding `shrink-to-fit=no` to the `content` attribute should remedy this.

Cheers!
