### PR TITLE
Create header-threecol-footer-responsive.md

### DIFF
--- a/_patterns/header-threecol-footer-responsive.md
+++ b/_patterns/header-threecol-footer-responsive.md
@@ -1,0 +1,20 @@
+-
+pattern-name: "Header, 3 col, footer"
+order: 2
+title: "Responsive header, three columns and a footer"
+main-image: pattern1.png
+pattern-desc: "A responsive, three column layout with a header and footer."
+layout: pattern
+pattern-codepen-embed: '<p data-height="565" data-theme-id="0" data-slug-hash="EooEej" data-default-tab="result" data-user="tomByrer" data-embed-version="2" data-pen-title="CSS grid  3 columns responsive version" class="codepen">See the Pen <a href="codepen.io/tomByrer/pen/EooEej/">Header, 3columns, footer responsive version</a> by tomByrer (<a href="https://codepen.io/tomByrer/</a>) on <a href="http://codepen.io">CodePen</a>.</p>'
+
+---
+
+This is example shows a three column pattern, with header and footer. Using media queries to move between a single and three column version. It could be a main page layout or a component of your page. The fallback uses floats and Feature Queries.
+
+## Techniques used to create this layout
+
+- [Defining a grid](/video/series-define-a-grid/)
+- [Template Areas](/video/grid-template-areas/)
+- [Feature Queries](/video/feature-queries/)
+
+Tips and techniques for fallback layouts can be found in my [Grid Fallbacks and Overrides Cheatsheet](https://rachelandrew.co.uk/css/cheatsheets/box-alignment).


### PR DESCRIPTION
Three column layout.

Oddities:
* 9 columns (2/9 looked better than 1/6 or 1/4)
* Right column goes to bottom rather than footer extending full width.  Wanted to show how template-area was good a odd-shaped grids.
* Rounded off fallback percentages.

Feel free to fork back to your own Codepen account.
https://codepen.io/tomByrer/pen/EooEej

Note: PR untested; I didn't build.  Meant as a discussion point.

Thanks for your resource & all you've done for the web!